### PR TITLE
sso fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
             mkdir /tmp/workspace
             cd rails-example
             bundle exec bin/rails assets:precompile
-            export VERSION="${RAILS_ENV}-$(expr $(date +%s) % 86400)"
+            export VERSION="${CIRCLE_BRANCH}-$(expr $(date +%s) % 86400)"
             gcloud app deploy --no-promote --version=${VERSION}
             bundle exec rake appengine:exec GAE_VERSION=${VERSION} -- bundle exec rake db:create db:migrate
             echo ${VERSION} > /tmp/workspace/rails_target_version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,7 +345,14 @@ workflows:
   version: 2
   terraform:
     jobs:
-      - enable_apis
+      - enable_apis:
+          filters:
+            branches:
+              only:
+                # This is the list of branches which will trigger a terraform run.
+                - master
+                - staging
+                - dev
       - plan_terraform:
           requires: 
             - enable_apis


### PR DESCRIPTION
fix it so that we aren't using RAILS_ENV during deploy, since it is missing.

filter which branches circle does terraform runs off of.